### PR TITLE
Invoke Python3 to run due.py

### DIFF
--- a/due
+++ b/due
@@ -14,5 +14,5 @@ shift
 }
 
 [ "$action" = "due" ] && {
-     python $(dirname $0)/due.py "$TODO_FILE" $flag
+     python3 $(dirname $0)/due.py "$TODO_FILE" $flag
 }


### PR DESCRIPTION
Invoking the script with a specific python interpreter makes the shebang in due.py meaningless. Due.py is not python2 compatible so always use python3